### PR TITLE
fix: 1 Now Vinícius Viana LinkedIn URL is correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@
 [![GitHub]](https://github.com/vinicius-roque)
 
 - Vinicius Viana
-[![LinkedIn]](https://www.linkedin.com/in/vinicius-viana-10a738247/)
+[![LinkedIn]](https://www.linkedin.com/in/vinícius-viana-10a738247/)
 [![GitHub]](https://github.com/ViniVian4)
 
 - Vitor Mangueira


### PR DESCRIPTION
In PR 12, when I brought data from Google Sheet, I had an issue with characters outside ASCII table. I rectified accentuation on names. Nevertheless, I let one link get away.

I checked all LinkedIn URL so far and only Vinícius Viana URL was withou accent. Now this is corrected.

I checked all GitHub URLs so far and all is correct.

I hope now everything is OK.